### PR TITLE
[NON-MODULAR] Less Dust.  More Corpses.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -983,13 +983,17 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 				investigate_log("has been gibbed by DNA instability.", INVESTIGATE_DEATHS)
 				gib(DROP_ALL_REMAINS)
 			if(1)
-				investigate_log("has been dusted by DNA instability.", INVESTIGATE_DEATHS)
-				dust()
+				/*investigate_log("has been dusted by DNA instability.", INVESTIGATE_DEATHS) /// SKYRAT REMOVAL BEGIN
+				dust()*/ /// SKYRAT REMOVAL END
+				investigate_log("has been gibbed by DNA instability.", INVESTIGATE_DEATHS)
+				gib(DROP_ALL_REMAINS) /// SKYRAT REPLACEMENT: Get gibbed instead, brain is recoverable
 			if(2)
-				investigate_log("has been transformed into a statue by DNA instability.", INVESTIGATE_DEATHS)
+				/*investigate_log("has been transformed into a statue by DNA instability.", INVESTIGATE_DEATHS) /// SKYRAT REMOVAL BEGIN
 				death()
 				petrify(statue_timer = INFINITY, save_brain = FALSE)
-				ghostize(FALSE)
+				ghostize(FALSE)*/ /// SKYRAT REMOVAL END
+				investigate_log("has been gibbed by DNA instability.", INVESTIGATE_DEATHS)
+				gib(DROP_ALL_REMAINS) /// SKYRAT REPLACEMENT: See above
 			if(3)
 				if(prob(95))
 					var/obj/item/bodypart/BP = get_bodypart(pick(BODY_ZONE_CHEST,BODY_ZONE_HEAD))

--- a/code/datums/status_effects/debuffs/decloning.dm
+++ b/code/datums/status_effects/debuffs/decloning.dm
@@ -61,8 +61,10 @@
 		owner.set_jitter_if_lower(30 SECONDS)
 
 	if(strikes_left == 0)
-		owner.visible_message(span_danger("[owner]'s skin turns to dust!"), span_boldwarning("Your skin turns to dust!"))
-		owner.dust()
+		/*owner.visible_message(span_danger("[owner]'s skin turns to dust!"), span_boldwarning("Your skin turns to dust!")) /// SKYRAT REMOVAL BEGIN
+		owner.dust()*/ /// SKYRAT REMOVAL END
+		owner.visible_message(span_danger("[owner]'s flesh sloughs off, body falling to pieces!"), span_boldwarning("Your flesh sloughs off, body falling to pieces!"))
+		owner.gib(DROP_ALL_REMAINS) /// SKYRAT REPLACEMENT: dust is bad, exploding into a shower of gore is better
 		return
 
 /datum/status_effect/decloning/get_examine_text()

--- a/code/game/objects/effects/anomalies/anomalies_flux.dm
+++ b/code/game/objects/effects/anomalies/anomalies_flux.dm
@@ -86,4 +86,5 @@
 
 	if(isliving(bumpee))
 		var/mob/living/living = bumpee
-		living.dust()
+		//living.dust() /// SKYRAT REMOVAL
+		living.gib(DROP_ALL_REMAINS) /// SKYRAT REPLACEMENT: dust is bad, exploding into a shower of gore is better

--- a/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
+++ b/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
@@ -66,7 +66,8 @@
 
 	if(isliving(bumpee))
 		var/mob/living/living = bumpee
-		living.dust()
+		//living.dust() /// SKYRAT REMOVAL
+		living.gib(DROP_ALL_REMAINS) /// SKYRAT REPLACEMENT: dust is bad, exploding into a shower of gore is better
 
 /obj/effect/anomaly/pyro/big/anomalyEffect(seconds_per_tick)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -195,8 +195,10 @@
 	if(isliving(target))
 		var/mob/living/dust_mob = target
 		if(dust_mob.stat == DEAD)
-			dust_mob.investigate_log("has been dusted by a death bolt (colossus).", INVESTIGATE_DEATHS)
-			dust_mob.dust()
+			/*dust_mob.investigate_log("has been dusted by a death bolt (colossus).", INVESTIGATE_DEATHS) /// SKYRAT REMOVAL BEGIN
+			dust_mob.dust()*/ /// SKYRAT REMOVAL END
+			dust_mob.investigate_log("has been gibbed by a death bolt (colossus).", INVESTIGATE_DEATHS)
+			dust_mob.gib(DROP_ALL_REMAINS) /// SKYRAT REPLACEMENT: you fuck with the colossus, you get exploded by his FUCKING mind
 		return
 	if(!explode_hit_objects || istype(target, /obj/vehicle/sealed))
 		return


### PR DESCRIPTION
## About The Pull Request

Removes being dusted from the following sources and replaces them with being exploded into a shower of technically-salvageable gore, should Medbay grace you with their efforts.

- The most controversial: Colossus (death bolt lethality is untouched, they just explode you into a shower of gore if you die)
- DNA instability (replaces petrification and dusting outcomes; may restore petrify IF it keeps the brain)
- Decloning debuff (possibly related to the above, may be a leftover of cloning machines?  better safe than sorry)
- Big Flux and Pyroclastic anomalies (I *think* these are admin spawns but I'd rather not risk it)

## How This Contributes To The Skyrat Roleplay Experience

Round removes/dusting are LRP as hell and I don't like them.

## Proof of Testing

The dust() proc is used less than, like, twenty times in the entire codebase.  I really don't need to provide this for my own server.

## Changelog

:cl:
del: removes dusting from a number of sources - you just explode into FUCKING gore now instead
/:cl:
