### PR TITLE
[SEMI-MODULAR] Kinkshaming TG

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -181,11 +181,12 @@
 	name = "alien stomach"
 	icon_state = "stomach-x"
 	w_class = WEIGHT_CLASS_BULKY
-	actions_types = list(/datum/action/cooldown/alien/regurgitate)
+	/// NOVA SECTOR REMOVAL BEGIN
+/*	actions_types = list(/datum/action/cooldown/alien/regurgitate)
 	var/list/atom/movable/stomach_contents = list()
 
 /obj/item/organ/internal/stomach/alien/Destroy()
-	QDEL_LIST(stomach_contents)
+	//QDEL_LIST(stomach_contents)
 	return ..()
 
 /obj/item/organ/internal/stomach/alien/on_life(seconds_per_tick, times_fired)
@@ -345,4 +346,5 @@
 		acid.reagents = acid_reagents
 		acid_reagents.my_atom = acid
 		acid_reagents.add_reagent(/datum/reagent/toxin/acid, 30)
-		acid.move_at(my_target, particle_delay, spit_range)
+		acid.move_at(my_target, particle_delay, spit_range)*/
+/// NOVA SECTOR REMOVAL END

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -181,12 +181,11 @@
 	name = "alien stomach"
 	icon_state = "stomach-x"
 	w_class = WEIGHT_CLASS_BULKY
-	/// NOVA SECTOR REMOVAL BEGIN
-/*	actions_types = list(/datum/action/cooldown/alien/regurgitate)
+	actions_types = list(/datum/action/cooldown/alien/regurgitate)
 	var/list/atom/movable/stomach_contents = list()
 
 /obj/item/organ/internal/stomach/alien/Destroy()
-	//QDEL_LIST(stomach_contents)
+	QDEL_LIST(stomach_contents)
 	return ..()
 
 /obj/item/organ/internal/stomach/alien/on_life(seconds_per_tick, times_fired)
@@ -196,9 +195,21 @@
 	// Digest the stuff in our stomach, just a bit
 	var/static/list/digestable_cache = typecacheof(list(/mob/living, /obj/item/food, /obj/item/reagent_containers))
 	for(var/atom/movable/thing as anything in stomach_contents)
-		if(!digestable_cache[thing.type])
+		/// NOVA SECTOR ADDITION BEGIN
+		var/atom/play_from = owner || src
+		playsound(get_turf(play_from), 'sound/mobs/non-humanoids/alien/alien_explode.ogg', 100, extrarange = 4)
+		eject_stomach(border_diamond_range_turfs(play_from, 6), 5, 1.5, 1, 8)
+		if(owner)
+			shake_camera(owner, 2, 5)
+			owner.investigate_log("has been gibbed by having something inside [owner.p_their()] stomach.", INVESTIGATE_DEATHS)
+			owner.gib(DROP_ALL_REMAINS)
+		qdel(src)
+		/// NOVA SECTOR ADDITION END
+		/// NOVA SECTOR REMOVAL BEGIN
+		/*if(!digestable_cache[thing.type])
 			continue
-		thing.acid_act(75, 10)
+		thing.acid_act(75, 10)*/
+		/// NOVA SECTOR REMOVAL END
 
 /obj/item/organ/internal/stomach/alien/proc/consume_thing(atom/movable/thing)
 	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(content_moved))
@@ -346,5 +357,4 @@
 		acid.reagents = acid_reagents
 		acid_reagents.my_atom = acid
 		acid_reagents.add_reagent(/datum/reagent/toxin/acid, 30)
-		acid.move_at(my_target, particle_delay, spit_range)*/
-/// NOVA SECTOR REMOVAL END
+		acid.move_at(my_target, particle_delay, spit_range)

--- a/modular_nova/modules/vore-b-gone/ooze_delete.dm
+++ b/modular_nova/modules/vore-b-gone/ooze_delete.dm
@@ -6,7 +6,5 @@
 
 /datum/action/consume/New(target)
 	. = ..()
-	// Allow necessary functions to avoid erroring before dying.
+	// Prevents this from being added manually.
 	Remove(target)
-	QDELL_NULL(src)
-	// Did you think you could add this manually?  Wrong.

--- a/modular_nova/modules/vore-b-gone/ooze_delete.dm
+++ b/modular_nova/modules/vore-b-gone/ooze_delete.dm
@@ -1,0 +1,12 @@
+/mob/living/simple_animal/hostile/ooze/Initialize(mapload)
+	. = ..()
+	// Allow necessary functions to avoid erroring before dying.
+	QDEL_NULL(src)
+	// Send them straight to nullspace.  All of them.
+
+/datum/action/consume/New(target)
+	. = ..()
+	// Allow necessary functions to avoid erroring before dying.
+	Remove(target)
+	QDELL_NULL(src)
+	// Did you think you could add this manually?  Wrong.

--- a/modular_nova/modules/vore-b-gone/xenovore_begone.dm
+++ b/modular_nova/modules/vore-b-gone/xenovore_begone.dm
@@ -1,0 +1,3 @@
+/mob/living/carbon/alien/adult/devour_lad(atom/movable/candidate, devour_time = 13.5 SECONDS)
+	return FALSE
+	// We're not even overriding this.  It's just dying.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8613,6 +8613,8 @@
 #include "modular_nova\modules\verbs\code\subtle.dm"
 #include "modular_nova\modules\veteran_only\code\job_types.dm"
 #include "modular_nova\modules\veteran_only\code\species_types.dm"
+#include "modular_nova\modules\vore-b-gone\ooze_delete.dm"
+#include "modular_nova\modules\vore-b-gone\xenovore_begone.dm"
 #include "modular_nova\modules\vox_sprites\code\color.dm"
 #include "modular_nova\modules\vox_sprites\code\head.dm"
 #include "modular_nova\modules\vox_sprites\code\security.dm"


### PR DESCRIPTION
## About The Pull Request

This is a straight-forward PR that removes fatal vore mechanics TG added - namely, Gelatinous Cubes (they qdel on birth, straight to nullspace), the mob consumption component (removes itself and then qdels for good measure as soon as it gets made), and the xenomorph vore ability (devour_lad is forever FALSE, and the necessary capabilities to support such on their stomach organ)

Additional removals may follow.

## How This Contributes To The Nova Sector Roleplay Experience

RR mechanics have never been good.  Prefbreaking people with fatal vore is worse.

## Proof of Testing

Hard to show off things that stopped existing.

## Changelog

:cl:
del: gelatinous cubes
del: mob consumption component
del: xenomorph vore
/:cl:
